### PR TITLE
Releasing ConvQA-TR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 📜 ConvQA-TR
-ConvQA-TR is a Conversational OpenQA system for Turkish.  It is currently in progress.  We would appreciate very much to hear your feedbacks while we are improving it currently.
+ConvQA-TR is a Conversational OpenQA system for Turkish.  You may review the full paper [here](https://doi.org/10.55730/1300-0632.4122), for further details.
 
 
 ### 🔬 Reproducibility 
@@ -8,7 +8,23 @@ You can find all code, models and samples of the input data [here](https://drive
 
  #### 🏷 ConvQA-TR License
 
-ConvQA-TR is licensed under the same terms as [SQuAD-TR](https://github.com/boun-tabi/SQuAD-TR) which is [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0).
+ConvQA-TR is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 
- #### ✍️ Authors
- - TBD
+
+### ✍️ Citation
+
+> [Budur, Emrah](https://scholar.google.com/citations?user=zSNd03UAAAAJ) and [Güngör, Tunga](https://www.cmpe.boun.edu.tr/~gungort) (2025) "Conversational open-domain question answering for resource-constrained languages," Turkish Journal of Electrical Engineering and Computer Sciences: Vol. 33: No. 2, Article 8. https://doi.org/10.55730/1300-0632.4122
+Available at: https://journals.tubitak.gov.tr/elektrik/vol33/iss2/8
+
+```
+@article{budur-and-gungor-2025-convqa-tr,
+  title={Conversational Open-Domain Question Answering for Resource-Constrained Languages},
+  author={Budur, Emrah and G\"{u}ng\"{o}r, Tunga},
+  journal={Turkish Journal of Electrical Engineering and Computer Sciences},
+  volume={33},
+  number={2},
+  pages={203--223},
+  year={2025}
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# convqa-tr
+# 📜 ConvQA-TR
+ConvQA-TR is a Conversational OpenQA system for Turkish.  It is currently in progress.  We would appreciate very much to hear your feedbacks while we are improving it currently.
+
+
+### 🔬 Reproducibility 
+
+You can find all code, models and samples of the input data [here](https://drive.google.com/drive/folders/13KmGt7c3n1RM7Sxv21GTCu2nBFMexebq?usp=sharing).  Please feel free to reach out to us if you have any specific questions. 
+
+ #### 🏷 ConvQA-TR License
+
+ConvQA-TR is licensed under the same terms as [SQuAD-TR](https://github.com/boun-tabi/SQuAD-TR) which is [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0).
+
+ #### ✍️ Authors
+ - TBD


### PR DESCRIPTION
Now that the paper has been released publicly ([ref](https://journals.tubitak.gov.tr/elektrik/vol33/iss2/8/)), we're also moving the changes in beta to the main branch.